### PR TITLE
Deprecate Antd Design System

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Each block is given a `BlockModel` from our server, which holds a key/value stor
 
 When the block is added to a card in production, it hooks into a fully functioning data layer using the same api that was previously mocked for your local development.
 
+### Design Systems
+
+With Seam blocks, you don't have to start from scratch. Learn from examples of existing blocks, and in addition, we use the [Material UI system (MUI)](https://mui.com/material-ui/getting-started/overview/). Browse the docs to use common components like buttons, selectors, and more. We are in the process of deprecating the `antd` library.
+
 ### Theming
 
 As the block developer, you decide how you want your block to reflect the global card theme. Each Seam card has a theme, which determines background color, block background color, font, and many other attributes. Themes are implemented as [`MUI Themes`](https://mui.com/material-ui/customization/theming/), which provides handy defaults and color palettes for theming components.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "iframe",
+    type: "image",
     data: {},
     uuid: "test"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "tweet",
+    type: "twitter",
     data: {},
     uuid: "test"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "link",
+    type: "tweet",
     data: {},
     uuid: "test"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "%NAME%",
+    type: "image",
     data: {},
     uuid: "test"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "image",
+    type: "iframe",
     data: {},
     uuid: "test"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   // vvvvvvvvvvvvvvvvv
 
   let yourBlock: BlockModel = {
-    type: "image",
+    type: "link",
     data: {},
     uuid: "test"
   }

--- a/src/Content.js
+++ b/src/Content.js
@@ -2,11 +2,12 @@
 // Don't edit anything in this file, it won't be reflected in production.
 
 import React, { useState } from "react";
-import { Card, Modal } from "antd";
 import { v1 as uuidv1 } from 'uuid';
 import { Responsive as ResponsiveGridLayout } from "react-grid-layout";
 import { withSize } from "react-sizeme";
 import Widget from "./Widget";
+import Card from '@mui/material/Card';
+import Modal from '@mui/material/Modal';
 
 // Blocks
 import BlockFactory from './blocks/BlockFactory';
@@ -50,22 +51,25 @@ function Content({ size: { width }, loadedBlocks }) {
       <Modal
         open={isEditingBlock !== -1}
         footer={null}
-        onCancel={() => setIsEditingBlock(-1)}
-        bodyStyle={{
-          padding: "15px",
-          fontSize: "17px",
-          fontWeight: "500",
+        onClose={() => setIsEditingBlock(-1)}
+        style={{ 
+          fontSize: "16px", 
+          fontWeight: "500" 
         }}
-        style={{ fontSize: "16px", fontWeight: "500" }}
       >
-        {"Edit Block " + isEditingBlock}
         <Card
           style={{
             marginTop: "10px",
             borderRadius: "1rem",
+            padding: "15px",
+            width: "50%",
+            position: 'absolute',
+            top: '10%',
+            left: '50%',
+            transform: 'translate(-50%, 0)',
           }}
-          bodyStyle={{ padding: "15px" }}
         >
+          {"Edit Block " + isEditingBlock}
           {block?.renderEditModal(saveBlockData)}
         </Card>
       </Modal>

--- a/src/blocks/IFrameBlock.tsx
+++ b/src/blocks/IFrameBlock.tsx
@@ -1,9 +1,11 @@
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input, message, Space } from "antd";
 import BlockFactory from './BlockFactory';
 import './BlockStyles.css'
 import Iframely from './utils/Iframely';
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 
 export default class IFrameBlock extends Block {
   render() {
@@ -45,14 +47,15 @@ export default class IFrameBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = async (values: any) => {
-      let url = values['url']
+    const onFinish = async (event: any) => {
+      event.preventDefault();
+      const data = new FormData(event.currentTarget);
+      let url = data.get('url') as string
       url = (url.indexOf('://') === -1) ? 'http://' + url : url;
       // Check to see if the iframe can embed properly. Many web2 walled gardens prevent direct embedding.
       const allowedResponse = await fetch("https://www.seam.so/api/iframe.js?url=" + url)
       const allowedJSON = await allowedResponse.json()
       const iframeAllowed = allowedJSON["iframeAllowed"]
-      console.log("iframe response: " + iframeAllowed)
       this.model.data['url'] = url
       this.model.data['iframeAllowed'] = iframeAllowed
       done(this.model)
@@ -63,40 +66,29 @@ export default class IFrameBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          url: this.model.data['url']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="url"
           label="URL"
           name="url"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add a url here',
-            },
-          ]}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/IFrameBlock.tsx
+++ b/src/blocks/IFrameBlock.tsx
@@ -75,6 +75,7 @@ export default class IFrameBlock extends Block {
           margin="normal"
           required
           fullWidth
+          defaultValue={this.model.data['url']}
           id="url"
           label="URL"
           name="url"

--- a/src/blocks/IFramelyBlock.tsx
+++ b/src/blocks/IFramelyBlock.tsx
@@ -1,9 +1,11 @@
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input } from "antd";
 import Iframely from './utils/Iframely';
 import BlockFactory from './BlockFactory';
 import './BlockStyles.css'
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 
 export default class BookmarkBlock extends Block {
   render() {
@@ -41,40 +43,30 @@ export default class BookmarkBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          url: this.model.data['url']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="url"
           label="URL"
           name="url"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add a url here',
-            },
-          ]}
+          defaultValue={this.model.data['url']}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/ImageBlock.tsx
+++ b/src/blocks/ImageBlock.tsx
@@ -1,8 +1,10 @@
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input } from "antd";
 import BlockFactory from './BlockFactory';
 import './BlockStyles.css'
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 
 export default class ImageBlock extends Block {
   render() {
@@ -28,8 +30,10 @@ export default class ImageBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (values: any) => {
-      let url = values['url']
+    const onFinish = (event: any) => {
+      event.preventDefault();
+      const data = new FormData(event.currentTarget);
+      let url = data.get('url') as string
       url = (url.indexOf('://') === -1) ? 'http://' + url : url;
       this.model.data['url'] = url
       done(this.model)
@@ -40,40 +44,29 @@ export default class ImageBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          url: this.model.data['url']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          id="url"
           label="URL"
           name="url"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add a url here',
-            },
-          ]}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/ImageBlock.tsx
+++ b/src/blocks/ImageBlock.tsx
@@ -52,6 +52,7 @@ export default class ImageBlock extends Block {
         <TextField
           margin="normal"
           required
+          defaultValue={this.model.data['url']}
           fullWidth
           id="url"
           label="URL"

--- a/src/blocks/LinkBlock.tsx
+++ b/src/blocks/LinkBlock.tsx
@@ -1,7 +1,9 @@
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input } from "antd";
 import BlockFactory from './BlockFactory';
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 
 export default class LinkBlock extends Block {
   render() {
@@ -16,17 +18,16 @@ export default class LinkBlock extends Block {
     }
 
     return (
-      <a href={url} target="_blank">
+      <a href={url} target="_blank" style={{textDecoration: "none"}}>
         <Button
-          block
-          type="primary"
-          ghost
+          variant="contained"
           style={{
             backgroundColor: `#0051E8`,
             color: 'white',
-            whiteSpace: "normal",
             height: '100%',
-            fontFamily: "Public Sans"
+            width: '100%',
+            fontFamily: "Public Sans",
+            textTransform: "none"
           }}>
           {title}
         </Button>
@@ -35,12 +36,14 @@ export default class LinkBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (values: any) => {
-      let url = values['url']
-      url = (url.indexOf(':') === -1) ? 'http://' + url : url;
-      
+    const onFinish = (event: any) => {
+      event.preventDefault();
+      const data = new FormData(event.currentTarget);
+      let url = data.get('url') as string
+      let title = data.get('title') as string
+      url = (url.indexOf('://') === -1) ? 'http://' + url : url;
       this.model.data['url'] = url
-      this.model.data['title'] = values['title']
+      this.model.data['title'] = title
       done(this.model)
     };
 
@@ -49,52 +52,39 @@ export default class LinkBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          url: this.model.data['url'],
-          title: this.model.data['title']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['title']}
+          fullWidth
+          id="title"
           label="Title"
           name="title"
-          rules={[
-            {
-              required: false,
-            },
-          ]}
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item
+          autoFocus
+        />
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['url']}
+          fullWidth
+          id="url"
           label="URL"
           name="url"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add a url here',
-            },
-          ]}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/LinkBlock.tsx
+++ b/src/blocks/LinkBlock.tsx
@@ -26,6 +26,7 @@ export default class LinkBlock extends Block {
             color: this.theme.palette.primary.main,
             whiteSpace: "normal",
             height: '100%',
+            width: '100%',
             fontFamily: this.theme.typography.fontFamily,
             textTransform: "none"
           }}>

--- a/src/blocks/ProfileBlock.tsx
+++ b/src/blocks/ProfileBlock.tsx
@@ -40,12 +40,14 @@ export default class ProfileBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (values: any) => {
-      console.log('Success:', values);
-      this.model.data['bio'] = values['bio']
-      this.model.data['title'] = values['title']
-      this.model.data['icons'] = values['icons']
-      done(this.model)
+    const onFinish = (event: any) => {
+      event.preventDefault();
+      const data = new FormData(event.currentTarget);
+      console.log('Success:', event.currentTarget);
+      this.model.data['bio'] = data.get('bio') as string
+      this.model.data['title'] = data.get('title') as string
+      this.model.data['icons'] = data.get('icons') as string
+      //done(this.model)
     };
 
     const onFinishFailed = (errorInfo: any) => {
@@ -89,7 +91,7 @@ export default class ProfileBlock extends Block {
         />
         {uploaderComponent}
         <Form />
-         <Button
+        <Button
           type="submit"
           variant="contained"
           className="save-modal-button"
@@ -195,42 +197,48 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 const Form: React.FC = () => {
-  const classes = useStyles();
-  const [inputRows, setInputRows] = useState<JSX.Element[]>([
-    <FormControl key={0} className={classes.formControl}>
-      <InputLabel htmlFor="input-1">Input 1</InputLabel>
-      <TextField id="input-1" />
-      <Button variant="contained" color="secondary" className={classes.button} onClick={() => deleteInputRow(0)}>
-        Delete
-      </Button>
-    </FormControl>,
-  ]);
+  const [formFields, setFormFields] = useState([
+    { name: '', age: '' },
+  ])
 
-  const addInputRow = () => {
-    const newInputRow = (
-      <FormControl key={inputRows.length} className={classes.formControl}>
-        <InputLabel htmlFor={`input-${inputRows.length + 1}`}>Input {inputRows.length + 1}</InputLabel>
-        <TextField id={`input-${inputRows.length + 1}`} />
-        <Button variant="contained" color="secondary" className={classes.button} onClick={() => deleteInputRow(inputRows.length)}>
-          Delete
-        </Button>
-      </FormControl>
-    );
-    setInputRows([...inputRows, newInputRow]);
-  };
+  const handleFormChange = (event: any, index: number) => {
+    let data: any = [...formFields];
+    data[index][event.target.name] = event.target.value;
+    setFormFields(data);
+  }
 
-  const deleteInputRow = (index: number) => {
-    const newInputRows = [...inputRows];
-    newInputRows.splice(index, 1);
-    setInputRows(newInputRows);
-  };
+  const addFields = () => {
+    let object = {
+      name: '',
+      age: ''
+    }
+
+    setFormFields([...formFields, object])
+  }
+
+  const removeFields = (index: number) => {
+    let data = [...formFields];
+    data.splice(index, 1)
+    setFormFields(data)
+  }
 
   return (
-    <form>
-      {inputRows}
-      <Button variant="contained" color="primary" className={classes.button} onClick={addInputRow}>
-        Add input
-      </Button>
-    </form>
+    <div>
+      {formFields.map((form, index) => {
+        return (
+          <div key={index}>
+            <IconsSelector />
+            <input
+              name='age'
+              placeholder='Age'
+              onChange={event => handleFormChange(event, index)}
+              value={form.age}
+            />
+            <button onClick={() => removeFields(index)}>Remove</button>
+          </div>
+        )
+      })}
+      <button onClick={addFields}>Add More..</button>
+    </div>
   );
 };

--- a/src/blocks/ProfileBlock.tsx
+++ b/src/blocks/ProfileBlock.tsx
@@ -5,7 +5,7 @@ import BlockFactory from './BlockFactory';
 import IconsRow, { IconsSelector } from './utils/IconsRow';
 import UploadFormComponent from './utils/UploadFormComponent';
 import { makeStyles, Theme, createStyles } from '@material-ui/core';
-import { Avatar, Button, Form, Input, Upload, Space } from "antd";
+import { Avatar, Button, Form, Input, Space } from "antd";
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 const { TextArea } = Input;
 

--- a/src/blocks/ProfileBlock.tsx
+++ b/src/blocks/ProfileBlock.tsx
@@ -4,12 +4,10 @@ import './BlockStyles.css'
 import BlockFactory from './BlockFactory';
 import IconsRow, { IconsSelector } from './utils/IconsRow';
 import UploadFormComponent from './utils/UploadFormComponent';
-import Avatar from '@material-ui/core/Avatar';
-import Box from "@mui/material/Box";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import React, { useState } from 'react';
-import { FormControl, InputLabel, makeStyles, Theme, createStyles } from '@material-ui/core';
+import { makeStyles, Theme, createStyles } from '@material-ui/core';
+import { Avatar, Button, Form, Input, Upload, Space } from "antd";
+import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
+const { TextArea } = Input;
 
 export default class ProfileBlock extends Block {
   render() {
@@ -40,14 +38,12 @@ export default class ProfileBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (event: any) => {
-      event.preventDefault();
-      const data = new FormData(event.currentTarget);
-      console.log('Success:', event.currentTarget);
-      this.model.data['bio'] = data.get('bio') as string
-      this.model.data['title'] = data.get('title') as string
-      this.model.data['icons'] = data.get('icons') as string
-      //done(this.model)
+    const onFinish = (values: any) => {
+      console.log('Success:', values);
+      this.model.data['bio'] = values['bio']
+      this.model.data['title'] = values['title']
+      this.model.data['icons'] = values['icons']
+      done(this.model)
     };
 
     const onFinishFailed = (errorInfo: any) => {
@@ -61,120 +57,80 @@ export default class ProfileBlock extends Block {
         this.model.data["imageURL"] = files[0].fileUrl
       }
     }} />
-
-    let iconList = this.model.data['icons']
+    
     return (
-      <Box
-        component="form"
-        onSubmit={onFinish}
-        style={{}}
+      <Form
+        name="basic"
+        initialValues={{
+          remember: true,
+          bio: this.model.data['bio'],
+          title: this.model.data['title'],
+          icons: this.model.data['icons']
+        }}
+        labelCol={{
+          span: 8,
+        }}
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        autoComplete="off"
       >
-        <TextField
-          margin="normal"
-          required
-          defaultValue={this.model.data['title']}
-          fullWidth
-          id="title"
-          label="Title"
+        <Form.Item
+          label="Name"
           name="title"
-        />
-        <TextField
-          margin="normal"
-          required
-          defaultValue={this.model.data['bio']}
-          fullWidth
-          id="bio"
+          rules={[
+            {
+              required: false,
+            },
+          ]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
           label="Bio"
           name="bio"
-          multiline
-          maxRows={2}
-        />
-        {uploaderComponent}
-        <Form />
-        <Button
-          type="submit"
-          variant="contained"
-          className="save-modal-button"
-          sx={{ mt: 3, mb: 2 }}
         >
-          Save
-        </Button>
-      </Box>
+          <TextArea showCount maxLength={280} />
+        </Form.Item>
+        <Form.Item label="Profile Photo">
+          {uploaderComponent}
+        </Form.Item>
+        <Form.List name="icons">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name, ...restField }) => (
+                <Space key={key} align="baseline">
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'icon']}
+                    rules={[{ required: true, message: 'Missing icon' }]}
+                  >
+                    {IconsSelector()}
+                  </Form.Item>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'url']}
+                    rules={[{ required: true, message: 'Missing icon url' }]}
+                  >
+                    <Input placeholder="URL" style={{width: "350px"}}/>
+                  </Form.Item>
+                  <MinusCircleOutlined onClick={() => remove(name)} />
+                </Space>
+              ))}
+              <Form.Item>
+                <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
+                  Add Social Icon
+                </Button>
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
+        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
+          <Button type="primary" htmlType="submit" className="save-modal-button">
+            Save
+          </Button>
+        </Form.Item>
+      </Form>
     )
-
-    // return (
-    //   <Form
-    //     name="basic"
-    //     initialValues={{
-    //       remember: true,
-    //       bio: this.model.data['bio'],
-    //       title: this.model.data['title'],
-    //       icons: this.model.data['icons']
-    //     }}
-    //     labelCol={{
-    //       span: 8,
-    //     }}
-    //     onFinish={onFinish}
-    //     onFinishFailed={onFinishFailed}
-    //     autoComplete="off"
-    //   >
-    //     <Form.Item
-    //       label="Name"
-    //       name="title"
-    //       rules={[
-    //         {
-    //           required: false,
-    //         },
-    //       ]}
-    //     >
-    //       <Input />
-    //     </Form.Item>
-    //     <Form.Item
-    //       label="Bio"
-    //       name="bio"
-    //     >
-    //       <TextArea showCount maxLength={280} />
-    //     </Form.Item>
-    //     <Form.Item label="Profile Photo">
-    //       {uploaderComponent}
-    //     </Form.Item>
-    //     <Form.List name="icons">
-    //       {(fields, { add, remove }) => (
-    //         <>
-    //           {fields.map(({ key, name, ...restField }) => (
-    //             <Space key={key} style={{ marginBottom: 8 }} align="baseline">
-    //               <Form.Item
-    //                 {...restField}
-    //                 name={[name, 'icon']}
-    //                 rules={[{ required: true, message: 'Missing icon' }]}
-    //               >
-    //                 {IconsSelector()}
-    //               </Form.Item>
-    //               <Form.Item
-    //                 {...restField}
-    //                 name={[name, 'url']}
-    //                 rules={[{ required: true, message: 'Missing icon url' }]}
-    //               >
-    //                 <Input placeholder="URL" />
-    //               </Form.Item>
-    //               <MinusCircleOutlined onClick={() => remove(name)} />
-    //             </Space>
-    //           ))}
-    //           <Form.Item>
-    //             <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
-    //               Add Social Icon
-    //             </Button>
-    //           </Form.Item>
-    //         </>
-    //       )}
-    //     </Form.List>
-    //     <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-    //       <Button type="primary" htmlType="submit" className="save-modal-button">
-    //         Save
-    //       </Button>
-    //     </Form.Item>
-    //   </Form>
-    // )
   }
 
   renderErrorState() {
@@ -195,50 +151,3 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   }),
 );
-
-const Form: React.FC = () => {
-  const [formFields, setFormFields] = useState([
-    { name: '', age: '' },
-  ])
-
-  const handleFormChange = (event: any, index: number) => {
-    let data: any = [...formFields];
-    data[index][event.target.name] = event.target.value;
-    setFormFields(data);
-  }
-
-  const addFields = () => {
-    let object = {
-      name: '',
-      age: ''
-    }
-
-    setFormFields([...formFields, object])
-  }
-
-  const removeFields = (index: number) => {
-    let data = [...formFields];
-    data.splice(index, 1)
-    setFormFields(data)
-  }
-
-  return (
-    <div>
-      {formFields.map((form, index) => {
-        return (
-          <div key={index}>
-            <IconsSelector />
-            <input
-              name='age'
-              placeholder='Age'
-              onChange={event => handleFormChange(event, index)}
-              value={form.age}
-            />
-            <button onClick={() => removeFields(index)}>Remove</button>
-          </div>
-        )
-      })}
-      <button onClick={addFields}>Add More..</button>
-    </div>
-  );
-};

--- a/src/blocks/ProfileBlock.tsx
+++ b/src/blocks/ProfileBlock.tsx
@@ -1,12 +1,15 @@
 import Block from './Block'
 import { BlockModel } from './types'
-import { Avatar, Button, Form, Input, Upload, Space, Select } from "antd";
-import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import './BlockStyles.css'
 import BlockFactory from './BlockFactory';
 import IconsRow, { IconsSelector } from './utils/IconsRow';
 import UploadFormComponent from './utils/UploadFormComponent';
-const { TextArea } = Input;
+import Avatar from '@material-ui/core/Avatar';
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import React, { useState } from 'react';
+import { FormControl, InputLabel, makeStyles, Theme, createStyles } from '@material-ui/core';
 
 export default class ProfileBlock extends Block {
   render() {
@@ -57,79 +60,119 @@ export default class ProfileBlock extends Block {
       }
     }} />
 
+    let iconList = this.model.data['icons']
     return (
-      <Form
-        name="basic"
-        initialValues={{
-          remember: true,
-          bio: this.model.data['bio'],
-          title: this.model.data['title'],
-          icons: this.model.data['icons']
-        }}
-        labelCol={{
-          span: 8,
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
-          label="Name"
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['title']}
+          fullWidth
+          id="title"
+          label="Title"
           name="title"
-          rules={[
-            {
-              required: false,
-            },
-          ]}
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item
+        />
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['bio']}
+          fullWidth
+          id="bio"
           label="Bio"
           name="bio"
+          multiline
+          maxRows={2}
+        />
+        {uploaderComponent}
+        <Form />
+         <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <TextArea showCount maxLength={280} />
-        </Form.Item>
-        <Form.Item label="Profile Photo">
-          {uploaderComponent}
-        </Form.Item>
-        <Form.List name="icons">
-          {(fields, { add, remove }) => (
-            <>
-              {fields.map(({ key, name, ...restField }) => (
-                <Space key={key} style={{ marginBottom: 8 }} align="baseline">
-                  <Form.Item
-                    {...restField}
-                    name={[name, 'icon']}
-                    rules={[{ required: true, message: 'Missing icon' }]}
-                  >
-                    {IconsSelector()}
-                  </Form.Item>
-                  <Form.Item
-                    {...restField}
-                    name={[name, 'url']}
-                    rules={[{ required: true, message: 'Missing icon url' }]}
-                  >
-                    <Input placeholder="URL" />
-                  </Form.Item>
-                  <MinusCircleOutlined onClick={() => remove(name)} />
-                </Space>
-              ))}
-              <Form.Item>
-                <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
-                  Add Social Icon
-                </Button>
-              </Form.Item>
-            </>
-          )}
-        </Form.List>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
+
+    // return (
+    //   <Form
+    //     name="basic"
+    //     initialValues={{
+    //       remember: true,
+    //       bio: this.model.data['bio'],
+    //       title: this.model.data['title'],
+    //       icons: this.model.data['icons']
+    //     }}
+    //     labelCol={{
+    //       span: 8,
+    //     }}
+    //     onFinish={onFinish}
+    //     onFinishFailed={onFinishFailed}
+    //     autoComplete="off"
+    //   >
+    //     <Form.Item
+    //       label="Name"
+    //       name="title"
+    //       rules={[
+    //         {
+    //           required: false,
+    //         },
+    //       ]}
+    //     >
+    //       <Input />
+    //     </Form.Item>
+    //     <Form.Item
+    //       label="Bio"
+    //       name="bio"
+    //     >
+    //       <TextArea showCount maxLength={280} />
+    //     </Form.Item>
+    //     <Form.Item label="Profile Photo">
+    //       {uploaderComponent}
+    //     </Form.Item>
+    //     <Form.List name="icons">
+    //       {(fields, { add, remove }) => (
+    //         <>
+    //           {fields.map(({ key, name, ...restField }) => (
+    //             <Space key={key} style={{ marginBottom: 8 }} align="baseline">
+    //               <Form.Item
+    //                 {...restField}
+    //                 name={[name, 'icon']}
+    //                 rules={[{ required: true, message: 'Missing icon' }]}
+    //               >
+    //                 {IconsSelector()}
+    //               </Form.Item>
+    //               <Form.Item
+    //                 {...restField}
+    //                 name={[name, 'url']}
+    //                 rules={[{ required: true, message: 'Missing icon url' }]}
+    //               >
+    //                 <Input placeholder="URL" />
+    //               </Form.Item>
+    //               <MinusCircleOutlined onClick={() => remove(name)} />
+    //             </Space>
+    //           ))}
+    //           <Form.Item>
+    //             <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
+    //               Add Social Icon
+    //             </Button>
+    //           </Form.Item>
+    //         </>
+    //       )}
+    //     </Form.List>
+    //     <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
+    //       <Button type="primary" htmlType="submit" className="save-modal-button">
+    //         Save
+    //       </Button>
+    //     </Form.Item>
+    //   </Form>
+    // )
   }
 
   renderErrorState() {
@@ -138,3 +181,56 @@ export default class ProfileBlock extends Block {
     )
   }
 }
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 120,
+    },
+    button: {
+      margin: theme.spacing(1),
+    },
+  }),
+);
+
+const Form: React.FC = () => {
+  const classes = useStyles();
+  const [inputRows, setInputRows] = useState<JSX.Element[]>([
+    <FormControl key={0} className={classes.formControl}>
+      <InputLabel htmlFor="input-1">Input 1</InputLabel>
+      <TextField id="input-1" />
+      <Button variant="contained" color="secondary" className={classes.button} onClick={() => deleteInputRow(0)}>
+        Delete
+      </Button>
+    </FormControl>,
+  ]);
+
+  const addInputRow = () => {
+    const newInputRow = (
+      <FormControl key={inputRows.length} className={classes.formControl}>
+        <InputLabel htmlFor={`input-${inputRows.length + 1}`}>Input {inputRows.length + 1}</InputLabel>
+        <TextField id={`input-${inputRows.length + 1}`} />
+        <Button variant="contained" color="secondary" className={classes.button} onClick={() => deleteInputRow(inputRows.length)}>
+          Delete
+        </Button>
+      </FormControl>
+    );
+    setInputRows([...inputRows, newInputRow]);
+  };
+
+  const deleteInputRow = (index: number) => {
+    const newInputRows = [...inputRows];
+    newInputRows.splice(index, 1);
+    setInputRows(newInputRows);
+  };
+
+  return (
+    <form>
+      {inputRows}
+      <Button variant="contained" color="primary" className={classes.button} onClick={addInputRow}>
+        Add input
+      </Button>
+    </form>
+  );
+};

--- a/src/blocks/TweetBlock.tsx
+++ b/src/blocks/TweetBlock.tsx
@@ -1,7 +1,9 @@
 import { TwitterTweetEmbed } from 'react-twitter-embed';
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input } from "antd";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 import BlockFactory from './BlockFactory';
 import './BlockStyles.css'
 
@@ -24,9 +26,9 @@ export default class TweetBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (values: any) => {
-      console.log('Success:', values);
-      this.model.data = values
+    const onFinish = (event: any) => {
+      const data = new FormData(event.currentTarget);
+      this.model.data['tweetId'] = data.get('tweetId') as string
       done(this.model)
     };
 
@@ -35,40 +37,30 @@ export default class TweetBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          url: this.model.data['tweetId']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['tweetId']}
+          fullWidth
+          id="tweetId"
           label="Tweet Id"
           name="tweetId"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add an ID here',
-            },
-          ]}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/TwitterBlock.tsx
+++ b/src/blocks/TwitterBlock.tsx
@@ -1,7 +1,9 @@
 import { TwitterTimelineEmbed } from 'react-twitter-embed';
 import Block from './Block'
 import { BlockModel } from './types'
-import { Button, Form, Input } from "antd";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
 import BlockFactory from './BlockFactory';
 import './BlockStyles.css'
 
@@ -34,8 +36,9 @@ export default class TwitterBlock extends Block {
   }
 
   renderEditModal(done: (data: BlockModel) => void) {
-    const onFinish = (values: any) => {
-      var name = values["name"]
+    const onFinish = (event: any) => {
+      const data = new FormData(event.currentTarget);
+      var name = data.get("name") as string
 
       // data sanitization to help with proper inputs
       var name1 = name.replace(/@/g, "")
@@ -53,40 +56,30 @@ export default class TwitterBlock extends Block {
     };
 
     return (
-      <Form
-        name="basic"
-        labelCol={{
-          span: 8,
-        }}
-        wrapperCol={{
-          span: 16,
-        }}
-        initialValues={{
-          remember: false,
-          name: this.model.data['name']
-        }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        autoComplete="off"
+      <Box
+        component="form"
+        onSubmit={onFinish}
+        style={{}}
       >
-        <Form.Item
+        <TextField
+          margin="normal"
+          required
+          defaultValue={this.model.data['name']}
+          fullWidth
+          id="name"
           label="Twitter Handle"
           name="name"
-          rules={[
-            {
-              required: true,
-              message: 'Wait, you didn\'t add a twitter handle here',
-            },
-          ]}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          className="save-modal-button"
+          sx={{ mt: 3, mb: 2 }}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-          <Button type="primary" htmlType="submit" className="save-modal-button">
-            Save
-          </Button>
-        </Form.Item>
-      </Form>
+          Save
+        </Button>
+      </Box>
     )
   }
 

--- a/src/blocks/utils/IconsRow.js
+++ b/src/blocks/utils/IconsRow.js
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
 
 export function IconsSelector() {
   return (
-    <Select style={{ width: "75px" }} id="icon">
+    <Select style={{ width: "75px" }} variant="standard" size="small" id="icon">
       <MenuItem value="twitter"><TwitterIcon /></MenuItem>
       <MenuItem value="instagram"><InstagramIcon /></MenuItem>
       <MenuItem value="linkedin"><LinkedIn /></MenuItem>

--- a/src/blocks/utils/IconsRow.js
+++ b/src/blocks/utils/IconsRow.js
@@ -1,4 +1,5 @@
-import { Select } from 'antd';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
 import { makeStyles } from "@material-ui/core/styles";
 import TwitterIcon from '@material-ui/icons/Twitter';
 import FacebookIcon from '@material-ui/icons/Facebook';
@@ -25,16 +26,16 @@ const useStyles = makeStyles((theme) => ({
 export function IconsSelector() {
   return (
     <Select style={{ width: "75px" }} id="icon">
-      <Option value="twitter"><TwitterIcon /></Option>
-      <Option value="instagram"><InstagramIcon /></Option>
-      <Option value="linkedin"><LinkedIn /></Option>
-      <Option value="discord"><img src={Discord} style={{ height: 20, color: "red" }} /></Option>
-      <Option value="tiktok"><img src={Tiktok} style={{ height: 20 }} /></Option>
-      <Option value="medium"><img src={mediumIcon} style={{ height: 20 }} /></Option>
-      <Option value="link"><LinkIcon /></Option>
-      <Option value="email"><EmailIcon /></Option>
-      <Option value="youtube"><YoutubeIcon /></Option>
-      <Option value="facebook"><FacebookIcon /></Option>
+      <MenuItem value="twitter"><TwitterIcon /></MenuItem>
+      <MenuItem value="instagram"><InstagramIcon /></MenuItem>
+      <MenuItem value="linkedin"><LinkedIn /></MenuItem>
+      <MenuItem value="discord"><img src={Discord} style={{ height: 20, color: "red" }} /></MenuItem>
+      <MenuItem value="tiktok"><img src={Tiktok} style={{ height: 20 }} /></MenuItem>
+      <MenuItem value="medium"><img src={mediumIcon} style={{ height: 20 }} /></MenuItem>
+      <MenuItem value="link"><LinkIcon /></MenuItem>
+      <MenuItem value="email"><EmailIcon /></MenuItem>
+      <MenuItem value="youtube"><YoutubeIcon /></MenuItem>
+      <MenuItem value="facebook"><FacebookIcon /></MenuItem>
     </Select>
   )
 }

--- a/src/blocks/utils/UploadFormComponent.tsx
+++ b/src/blocks/utils/UploadFormComponent.tsx
@@ -28,6 +28,7 @@ export default function UploadFormComponent(
   return (
     <UploadDropzone uploader={uploader}
       options={options}        
-      onUpdate={onUpdate}/>
+      onUpdate={onUpdate}
+      height="200px"/>
   )
 }


### PR DESCRIPTION
Currently, Seam blocks use two design systems interchangeably: the MUI design system and the Antd design system. Both do roughly the same things in terms of defined components. This PR deprecates the Antd library in favor of MUI to:
1. reduce complexity: only one design system to support
2. decrease bundle size: there was a lot of duplication supporting both
3. increase block sdk load times

Unfortunately, antd is still better at dynamic forms, and so the profile block, and the corresponding icon row, still has a depedency on antd meaning that I can't clean it up entirely yet. Nevertheless, this PR is a good start at cleaning up antd and preventing new blocks from using the antd form pattern.