### PR TITLE
Fix display heights of demo blocks in App.tsx

### DIFF
--- a/src/Content.js
+++ b/src/Content.js
@@ -105,7 +105,7 @@ function Content({ size: { width }, loadedBlocks }) {
           <div
             key={model.uuid}
             className="widget"
-            data-grid={{ w: 3, h: 2, x: 0, y: Infinity }}
+            data-grid={{ w: 5, h: 15, x: 0, y: Infinity }}
           >
             <Widget id={model.uuid}
               onRemoveItem={onRemoveItem}


### PR DESCRIPTION
Fixes #6 

## Test Plan

### Before

<img width="710" alt="Screen Shot 2023-01-17 at 12 49 38 AM" src="https://user-images.githubusercontent.com/8518543/212820349-7bd898e5-92dd-42e2-8c60-3ce543fbdca8.png">


### After

<img width="696" alt="Screen Shot 2023-01-17 at 12 49 25 AM" src="https://user-images.githubusercontent.com/8518543/212820363-021d5921-9f61-4f30-bdc6-b31842da1337.png">


### Test Repro

To test locally, add the following to `App.tsx`:

```typescript
export default function App() {
  const classes = useStyles();

  // Add your custom block here!
  // vvvvvvvvvvvvvvvvv

  let yourBlock: BlockModel = {
    type: "iframe",
    data: {},
    uuid: "test"
  }

  let yourBlock2: BlockModel = {
    type: "giphy",
    data: {},
    uuid: "test2"
  }

  let yourBlock3: BlockModel = {
    type: "giphy",
    data: {},
    uuid: "test3"
  }

  // End customization
  // ^^^^^^^^^^^^^^^^^

  return (
    <ThemeProvider theme={defaultTheme}>
      <div className={classes.root}>
        <h1> Seam Block SDK </h1>
        <Content loadedBlocks={[yourBlock, yourBlock2, yourBlock3]} />
      </div>
    </ThemeProvider>
  );
}
```