### PR TITLE
Handle resizing by filling background color

### DIFF
--- a/src/blocks/PixelArtBlock.tsx
+++ b/src/blocks/PixelArtBlock.tsx
@@ -349,8 +349,6 @@ const PixelCanvas: React.FC<PixelCanvasProps> = (props: PixelCanvasProps) => {
   )
 }
 
-// const PixelCanvasWithSize = withSize()(PixelCanvas);
-
 const PixelCanvasWithSize = (props: BasePixelCanvasProps) => {
   return (
     <SizeMe monitorHeight refreshMode='debounce'>


### PR DESCRIPTION
This handles resizing by filling in the background color rather than stretching the image out of its aspect ratio.

# Before

![resize-demo-before](https://user-images.githubusercontent.com/8518543/220250031-72af7495-8586-4c5d-a67c-708a46bc6e7b.gif)

# After

![resize-demo](https://user-images.githubusercontent.com/8518543/220249588-7ca66af6-b435-4a3f-b20e-c0f09c71050d.gif)

# Note

Unfortunately, the vertical resizing feature does not work because of something in the breakpoints from the parent component. When the height <= maxWidth, the SizeMe in the child reads the height as maxWidth rather than height. This is the behavior for all other blocks as well. Not sure if this is a feature or a bug, however the code introduced in this PR will be able to handle any updates to resizing behavior across all blocks in the future.
