### PR TITLE
Fixed music block edit modal not saving block header on close

### DIFF
--- a/src/blocks/IFramelyBlock.tsx
+++ b/src/blocks/IFramelyBlock.tsx
@@ -72,7 +72,7 @@ export default class BookmarkBlock extends Block {
           id="header"
           label="Header Title"
           name="header"
-          defaultValue={this.model.data['header']}
+          defaultValue={this.model.data['title']}
         />
         <Button
           type="submit"


### PR DESCRIPTION
- Header for music block now persists through closing and reopening the edit modal. 


![image](https://github.com/seam-xyz/Block-SDK/assets/84438045/6fb8dea1-a022-4633-a191-8d3128841a4c)


